### PR TITLE
Persist last production press selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+production.db
+__pycache__/

--- a/templates/production.html
+++ b/templates/production.html
@@ -2,17 +2,18 @@
 
 {% block content %}
   <h2>Production</h2>
-  <div>
+  <form method="POST">
     {% for part in parts %}
       <div style="margin-bottom: 15px;">
         <strong>{{ part }}</strong><br>
         <select name="press_{{ loop.index0 }}">
           {% for press in presses %}
-            <option value="{{ press }}">{{ press }}</option>
+            <option value="{{ press }}" {% if assignments.get(part) == press %}selected{% endif %}>{{ press }}</option>
           {% endfor %}
         </select>
       </div>
     {% endfor %}
-  </div>
+    <button type="submit">Save</button>
+  </form>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- store production press selections in a new SQLite database
- populate production page with previously saved selections
- ignore generated database file in git

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689348427c88832f911393db2d8e064e