### PR TITLE
Color code schedule names by training level

### DIFF
--- a/templates/generated_schedule.html
+++ b/templates/generated_schedule.html
@@ -16,10 +16,13 @@
       text-align: center;
     }
     .person-name {
-      background-color: #ffffff;
       padding: 4px;
       text-align: center;
     }
+    .person-name.level-1 { background-color: #ff4c4c; }
+    .person-name.level-2 { background-color: #ffb3b3; }
+    .person-name.level-3 { background-color: #90ee90; }
+    .person-name.level-4 { background-color: #00b300; }
   </style>
   <h2>Generated Schedule</h2>
   <div class="schedule-grid">
@@ -27,7 +30,11 @@
     <div class="station-box">
       <div class="station-header">{{ station }}</div>
       {% for person in people %}
-      <div class="person-name">{{ person }}</div>
+      {% if person %}
+      <div class="person-name level-{{ levels.get(person, 1) }}">{{ person }}</div>
+      {% else %}
+      <div class="person-name"></div>
+      {% endif %}
       {% endfor %}
     </div>
     {% endfor %}

--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -7,6 +7,15 @@
     .schedule-table select {
       width: 150px;
     }
+    .level-1, .level-2, .level-3, .level-4 {
+      color: #000;
+      display: block;
+      padding: 2px 4px;
+    }
+    .level-1 { background-color: #ff4c4c; }
+    .level-2 { background-color: #ffb3b3; }
+    .level-3 { background-color: #90ee90; }
+    .level-4 { background-color: #00b300; }
   </style>
   <h2>Schedule</h2>
   {% if session.get('last_schedule') %}
@@ -34,7 +43,7 @@
           <select class="person-select" name="station{{ idx }}_{{ i }}">
             <option value="">-- Select --</option>
             {% for name in names %}
-              <option value="{{ name }}">{{ name }}</option>
+              <option value="{{ name }}" data-level="{{ levels[name] }}" class="level-{{ levels[name] }}">{{ name }}</option>
             {% endfor %}
           </select>
         </td>
@@ -51,7 +60,20 @@
   <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
   <script>
     $(function(){
-      $('.person-select').select2();
+      function formatName(state) {
+        if (!state.id) { return state.text; }
+        var level = $(state.element).data('level');
+        var $state = $('<span>' + state.text + '</span>');
+        if (level) {
+          $state.addClass('level-' + level);
+        }
+        return $state;
+      }
+
+      $('.person-select').select2({
+        templateResult: formatName,
+        templateSelection: formatName
+      });
 
       function updateOptions() {
         var selected = [];


### PR DESCRIPTION
## Summary
- compute average training level per person from workbook
- color code schedule dropdown options and generated schedule by training level

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
from app import load_workbook_data, compute_overall_levels
_, _, _, data = load_workbook_data()
levels = compute_overall_levels(data)
print(list(levels.items())[:5])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68934e5c4ae0832fa51a6572d28bc97c