### PR TITLE
Color schedule by part

### DIFF
--- a/app.py
+++ b/app.py
@@ -99,6 +99,20 @@ def compute_overall_levels(data):
     return levels
 
 
+def compute_part_levels(data):
+    """Return training level lookup per part and person.
+
+    The returned mapping has the form {part: {name: level}} allowing
+    templates to color code people based on the specific part instead of
+    an overall average.
+    """
+    levels = {}
+    for name, skills in data.items():
+        for part, level in skills.items():
+            levels.setdefault(part, {})[name] = level
+    return levels
+
+
 app = Flask(__name__)
 app.secret_key = "dev"
 
@@ -209,7 +223,7 @@ def schedule():
     """Display a table of stations with a dropdown of workers for each."""
     _, _, _, data = load_workbook_data()
     names = sorted(data.keys())
-    levels = compute_overall_levels(data)
+    levels = compute_part_levels(data)
     stations = list(enumerate(STATIONS))
     return render_template("schedule.html", stations=stations, names=names, levels=levels)
 
@@ -234,7 +248,7 @@ def view_schedule():
     if not schedule:
         return redirect(url_for('schedule'))
     _, _, _, data = load_workbook_data()
-    levels = compute_overall_levels(data)
+    levels = compute_part_levels(data)
     return render_template("generated_schedule.html", schedule=schedule, levels=levels)
 
 @app.route("/decrease", methods=["GET", "POST"])

--- a/templates/generated_schedule.html
+++ b/templates/generated_schedule.html
@@ -31,7 +31,8 @@
       <div class="station-header">{{ station }}</div>
       {% for person in people %}
       {% if person %}
-      <div class="person-name level-{{ levels.get(person, 1) }}">{{ person }}</div>
+      {% set lvl = levels.get(station, {}).get(person, 1) %}
+      <div class="person-name level-{{ lvl }}">{{ person }}</div>
       {% else %}
       <div class="person-name"></div>
       {% endif %}

--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -43,7 +43,8 @@
           <select class="person-select" name="station{{ idx }}_{{ i }}">
             <option value="">-- Select --</option>
             {% for name in names %}
-              <option value="{{ name }}" data-level="{{ levels[name] }}" class="level-{{ levels[name] }}">{{ name }}</option>
+              {% set lvl = levels.get(station, {}).get(name, 1) %}
+              <option value="{{ name }}" data-level="{{ lvl }}" class="level-{{ lvl }}">{{ name }}</option>
             {% endfor %}
           </select>
         </td>


### PR DESCRIPTION
## Summary
- compute training levels per part and person
- color schedule options using the matching part level instead of overall average

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689354d2d3d0832fbdd4480055ca7c0c