### PR TITLE
Store and view schedules by date

### DIFF
--- a/templates/generated_schedule.html
+++ b/templates/generated_schedule.html
@@ -24,7 +24,7 @@
     .person-name.level-3 { background-color: #90ee90; }
     .person-name.level-4 { background-color: #00b300; }
   </style>
-  <h2>Generated Schedule</h2>
+  <h2>Generated Schedule{% if selected_date %} for {{ selected_date }}{% endif %}</h2>
   <div class="schedule-grid">
     {% for station, people in schedule.items() %}
     <div class="station-box">
@@ -42,6 +42,6 @@
   </div>
   <p style="margin-top:1em;">
     <a href="{{ url_for('schedule') }}">Back to Schedule Page</a> |
-    <a href="{{ url_for('view_schedule') }}">Reload Generated Schedule</a>
+    <a href="{{ url_for('view_schedule', date=selected_date) if selected_date else url_for('view_schedule') }}">Reload Generated Schedule</a>
   </p>
 {% endblock %}

--- a/templates/previous_schedules.html
+++ b/templates/previous_schedules.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block content %}
+  <h2>Previous Schedules</h2>
+  <p>Select a date to view a schedule:</p>
+  <input type="date" id="scheduleDate">
+  <script>
+    document.getElementById('scheduleDate').addEventListener('change', function(){
+      var date = this.value;
+      if(date){
+        window.location = "{{ url_for('view_schedule') }}?date=" + date;
+      }
+    });
+  </script>
+{% endblock %}

--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -40,11 +40,13 @@
         <td>{{ station }}</td>
         {% for i in range(6) %}
         <td>
+          {% set pre = prev_schedule.get(station, []) %}
           <select class="person-select" name="station{{ idx }}_{{ i }}">
             <option value="">-- Select --</option>
             {% for name in names %}
               {% set lvl = levels.get(station, {}).get(name, 1) %}
-              <option value="{{ name }}" data-level="{{ lvl }}" class="level-{{ lvl }}">{{ name }}</option>
+              {% set selected = 'selected' if pre|length > i and pre[i] == name else '' %}
+              <option value="{{ name }}" data-level="{{ lvl }}" class="level-{{ lvl }}" {{ selected }}>{{ name }}</option>
             {% endfor %}
           </select>
         </td>
@@ -55,6 +57,7 @@
   </table>
   <p style="margin-top:1em;"><a href="#" id="generateLink">Generate Schedule</a></p>
   </form>
+  <p><a href="{{ url_for('previous_schedules') }}">View Previous Schedules</a></p>
 
   <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
   <script src="https://code.jquery.com/jquery-3.5.1.min.js"></script>


### PR DESCRIPTION
## Summary
- Persist generated schedules in a new SQLite table keyed by date
- Auto-fill schedule page with previous day assignments and add link to calendar for historical schedules
- Allow viewing schedules for any date and display selected date in generated schedule view

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6894b968e640832f87d6893aee244b79